### PR TITLE
Add support to i2p network type

### DIFF
--- a/core/src/main/java/com/neemre/btcdcli4j/core/common/Defaults.java
+++ b/core/src/main/java/com/neemre/btcdcli4j/core/common/Defaults.java
@@ -12,6 +12,6 @@ public final class Defaults {
 	public static final int DECIMAL_SCALE = 8;
 	public static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
 
-	public static final String[] NODE_VERSIONS = {"0.10.0", "0.10.1", "0.10.2", "0.10.3", "0.15.0", "0.16.0", "0.16.1", "0.16.2"};
+	public static final String[] NODE_VERSIONS = {"0.10.0", "0.10.1", "0.10.2", "0.10.3", "0.15.0", "0.16.0", "0.16.1", "0.16.2", "0.21.0", "0.21.1", "0.22.0"};
 	public static final String JSON_RPC_VERSION = "1.0";
 }

--- a/core/src/main/java/com/neemre/btcdcli4j/core/domain/enums/NetworkTypes.java
+++ b/core/src/main/java/com/neemre/btcdcli4j/core/domain/enums/NetworkTypes.java
@@ -18,7 +18,8 @@ public enum NetworkTypes {
 
 	IPV4("ipv4"),
 	IPV6("ipv6"),
-	ONION("onion");
+	ONION("onion"),
+	I2P("i2p");
 
 	private final String name;
 


### PR DESCRIPTION
Mapper crash here:

```
NetworkInfo networkInfo = rpcClient.getMapper().mapToEntity(networkInfoJson, 
      NetworkInfo.class);
```

Because the response contains:

```
"networks": [
      {
        "name": "ipv4",
        "limited": false,
        "reachable": true,
        "proxy": "",
        "proxy_randomize_credentials": false
      },
      {
        "name": "ipv6",
        "limited": false,
        "reachable": true,
        "proxy": "",
        "proxy_randomize_credentials": false
      },
      {
        "name": "onion",
        "limited": true,
        "reachable": false,
        "proxy": "",
        "proxy_randomize_credentials": false
      },
      {
        "name": "i2p",
        "limited": true,
        "reachable": false,
        "proxy": "",
        "proxy_randomize_credentials": false
      }
    ],
```

But i2p is not supported by the library.

![image](https://user-images.githubusercontent.com/10439162/141344068-54c2d2c7-d7cb-409b-95f1-5d3cb243322c.png)
