### PR TITLE
Fix getRawTransaction with verbosity method in order to populate the …

### DIFF
--- a/core/src/main/java/com/neemre/btcdcli4j/core/domain/PubKeyScript.java
+++ b/core/src/main/java/com/neemre/btcdcli4j/core/domain/PubKeyScript.java
@@ -2,6 +2,8 @@ package com.neemre.btcdcli4j.core.domain;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -24,5 +26,8 @@ public class PubKeyScript extends SignatureScript {
 	
 	private Integer reqSigs;
 	private ScriptTypes type;
+	// When comes with a list of addresses
 	private List<String> addresses;
+	// When comes only with 1 address
+	private String address;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
 		<jdk.version>1.8</jdk.version>
-		<jackson.version>2.5.0</jackson.version>
+		<jackson.version>2.9.0</jackson.version>
 		<slf4j.version>1.7.25</slf4j.version>
 		<commons-lang.version>3.3.2</commons-lang.version>
 	</properties>


### PR DESCRIPTION
When a transaction returns in the vout field only 1 address, the returned field is a simple `address`. But this is breaking the original behaviour in which we map the addresses of the vout to a list.

This hack fixes this and always populates the list.