### PR TITLE
Fixed @ CVE-2020-13956

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.3.6</version>
+			<version>4.5.13</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
## Description Overview
Apache HttpClient versions prior 5.0.3 can misinterpret malformed authority component in request URIs passed to the library as java.net.URI object and pick the wrong target host for request execution. Affected of this package are vulnerable to Improper Input Validation. Apache HttpClient can misinterpret malformed authority component in request URIs passed to the library as java.net.URI object and pick the wrong target host for request execution.

[CVE-2020-13956](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-13956)
CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N
[Github Advisitory](https://deps.dev/advisory/GHSA/GHSA-7r82-7xv7-xcpj)