### PR TITLE
Witness unknown script type added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ target/
 # Project-specific patterns
 logs/
 cloc_analysis_14122015.txt
+*.iml
+.idea/

--- a/core/src/main/java/com/neemre/btcdcli4j/core/domain/RawInput.java
+++ b/core/src/main/java/com/neemre/btcdcli4j/core/domain/RawInput.java
@@ -27,4 +27,5 @@ public class RawInput extends Entity {
 	private SignatureScript scriptSig;
 	private String coinbase;
 	private Long sequence;
+	private boolean ismweb;
 }

--- a/core/src/main/java/com/neemre/btcdcli4j/core/domain/RawOutput.java
+++ b/core/src/main/java/com/neemre/btcdcli4j/core/domain/RawOutput.java
@@ -28,11 +28,17 @@ public class RawOutput extends Entity {
 	private PubKeyScript scriptPubKey;
 	private boolean ismweb;
 
-
 	public RawOutput(BigDecimal value, Integer n, PubKeyScript scriptPubKey) {
 		setValue(value);
 		setN(n);
 		setScriptPubKey(scriptPubKey);
+	}
+
+	public RawOutput(BigDecimal value, Integer n, PubKeyScript scriptPubKey, boolean ismweb) {
+		setValue(value);
+		setN(n);
+		setScriptPubKey(scriptPubKey);
+		setIsmweb(ismweb);
 	}
 
 	public void setValue(BigDecimal value) {

--- a/core/src/main/java/com/neemre/btcdcli4j/core/domain/RawOutput.java
+++ b/core/src/main/java/com/neemre/btcdcli4j/core/domain/RawOutput.java
@@ -26,6 +26,7 @@ public class RawOutput extends Entity {
 	private BigDecimal value;
 	private Integer n;
 	private PubKeyScript scriptPubKey;
+	private boolean ismweb;
 
 
 	public RawOutput(BigDecimal value, Integer n, PubKeyScript scriptPubKey) {

--- a/core/src/main/java/com/neemre/btcdcli4j/core/domain/enums/ScriptTypes.java
+++ b/core/src/main/java/com/neemre/btcdcli4j/core/domain/enums/ScriptTypes.java
@@ -24,7 +24,8 @@ public enum ScriptTypes {
 	NONSTANDARD("nonstandard"),
 	WITNESS_V0_KEYHASH("witness_v0_keyhash"),
 	WITNESS_V0_SCRIPTHASH("witness_v0_scripthash"),
-	WITNESS_V1_TAPROOT("witness_v1_taproot");
+	WITNESS_V1_TAPROOT("witness_v1_taproot"),
+	WITNESS_UNKNOWN("withness_unknown");
 	
 	private final String name;
 
@@ -43,6 +44,6 @@ public enum ScriptTypes {
 				}
 			}
 		}
-		throw new IllegalArgumentException(Errors.ARGS_BTCD_SCRIPTTYPE_UNSUPPORTED.getDescription());
+		throw new IllegalArgumentException(String.format("%s - %s", Errors.ARGS_BTCD_SCRIPTTYPE_UNSUPPORTED.getDescription(), name));
 	}
 }

--- a/core/src/main/java/com/neemre/btcdcli4j/core/domain/enums/ScriptTypes.java
+++ b/core/src/main/java/com/neemre/btcdcli4j/core/domain/enums/ScriptTypes.java
@@ -25,7 +25,9 @@ public enum ScriptTypes {
 	WITNESS_V0_KEYHASH("witness_v0_keyhash"),
 	WITNESS_V0_SCRIPTHASH("witness_v0_scripthash"),
 	WITNESS_V1_TAPROOT("witness_v1_taproot"),
-	WITNESS_UNKNOWN("withness_unknown");
+	WITNESS_UNKNOWN("witness_unknown"),
+	WITNESS_MWEB_PEGIN("witness_mweb_pegin"),
+	WITNESS_MWEB_HOGADDR("withness_mweb_hogaddr");
 	
 	private final String name;
 


### PR DESCRIPTION
## Description
Withness unknown script type added due to a parsing error when processing LTC deposits.

## Types added
- WITNESS_UNKNOWN
- WITNESS_MWEB_PEGIN
- WITNESS_MWEB_HOGADDR

[Warroom link](https://bitso.slack.com/archives/C04R3UNAB5F)

[Thread for context](https://bitso.slack.com/archives/C04R3UNAB5F/p1677076510400189?thread_ts=1677072815.360699&cid=C04R3UNAB5F)