### PR TITLE
Add cjdns network type

### DIFF
--- a/core/src/main/java/com/neemre/btcdcli4j/core/domain/enums/NetworkTypes.java
+++ b/core/src/main/java/com/neemre/btcdcli4j/core/domain/enums/NetworkTypes.java
@@ -20,6 +20,7 @@ public enum NetworkTypes {
 	IPV6("ipv6"),
 	ONION("onion"),
 	I2P("i2p"),
+	CJDNS("cjdns"),
 	EMPTY("");
 
 	private final String name;


### PR DESCRIPTION
Add cjdns network type which is returned on `getnetworkinfo` json-rpc response for bitcoin-core version 28

```json
{
  "result": {
    "version": 280100,
    "subversion": "/Satoshi:28.1.0/",
    "protocolversion": 70016,
    "localservices": "0000000000000c09",
    "localservicesnames": [
      "NETWORK",
      "WITNESS",
      "NETWORK_LIMITED",
      "P2P_V2"
    ],
    "localrelay": true,
    "timeoffset": 1,
    "networkactive": true,
    "connections": 10,
    "connections_in": 0,
    "connections_out": 10,
    "networks": [
      {
        "name": "ipv4",
        "limited": false,
        "reachable": true,
        "proxy": "",
        "proxy_randomize_credentials": false
      },
      {
        "name": "ipv6",
        "limited": false,
        "reachable": true,
        "proxy": "",
        "proxy_randomize_credentials": false
      },
      {
        "name": "onion",
        "limited": true,
        "reachable": false,
        "proxy": "",
        "proxy_randomize_credentials": false
      },
      {
        "name": "i2p",
        "limited": true,
        "reachable": false,
        "proxy": "",
        "proxy_randomize_credentials": false
      },
      {
        "name": "cjdns",
        "limited": true,
        "reachable": false,
        "proxy": "",
        "proxy_randomize_credentials": false
      }
    ],
    "relayfee": 0.00001000,
    "incrementalfee": 0.00001000,
    "localaddresses": [],
    "warnings": []
  },
  "error": null,
  "id": "curltest"
}
```