### PR TITLE
Potential fix for code scanning alert no. 1: Failure to use HTTPS or SFTP URL in Maven artifact upload/download

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,14 +25,6 @@
 		<module>examples</module>
 	</modules>
 
-	<distributionManagement>
-		<repository>
-			<id>mvn-nemp-ftp</id>
-			<name>Nemp's Maven Repository</name>
-			<url>sftp://nemp.planet.ee/htdocs/mvn/</url>
-		</repository>
-	</distributionManagement>
-
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<repository>
 			<id>mvn-nemp-ftp</id>
 			<name>Nemp's Maven Repository</name>
-			<url>ftp://nemp.planet.ee/htdocs/mvn/</url>
+			<url>sftp://nemp.planet.ee/htdocs/mvn/</url>
 		</repository>
 	</distributionManagement>
 


### PR DESCRIPTION
Potential fix for [https://github.com/bitsoex/btcd-cli4j/security/code-scanning/1](https://github.com/bitsoex/btcd-cli4j/security/code-scanning/1)

To fix the issue, the `ftp` protocol in the repository URL should be replaced with a secure protocol such as `SFTP` or `HTTPS`. This ensures that data is transmitted securely, protecting against MITM attacks. The exact replacement URL should be verified with the repository administrator to ensure compatibility and correctness.

In this case, we will assume that the repository supports `SFTP` and update the URL accordingly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
